### PR TITLE
Fix _checkGiveaway interval value being null

### DIFF
--- a/lib/giveaways/Constants.ts
+++ b/lib/giveaways/Constants.ts
@@ -152,7 +152,7 @@ export const PauseOptions: PauseOptions = {
 
 export const GiveawayManagerOptions: GiveawaysManagerOptions = {
     storage: "./giveaways.json",
-    forceUpdateEvery: 10000,
+    forceUpdateEvery: null,
     endedGiveawaysLifetime: null,
     default: {
         botsCanWin: false,

--- a/lib/giveaways/GiveawaysManager.ts
+++ b/lib/giveaways/GiveawaysManager.ts
@@ -230,7 +230,7 @@ export class GiveawaysManager extends EventEmitter {
 
         setInterval(() => {
             if (this.client.startTime) this._checkGiveaway.call(this);
-        }, this.options.forceUpdateEvery);
+        }, this.options.forceUpdateEvery || 15_000);
 
         this.ready = true;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "givies-framework",
-  "version": "2022.407.2",
+  "version": "2022.408.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "givies-framework",
-      "version": "2022.407.2",
+      "version": "2022.408.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givies-framework",
-  "version": "2022.407.2",
+  "version": "2022.408.0",
   "description": "A framework to facilitate the development of Discord bots using Eris",
   "main": "src/index.js",
   "engines": {


### PR DESCRIPTION
The interval value should be 15 seconds but I forgot to include this fix in the last PR. 

# Change Logs

- `forceUpdateEvery` should be null by default (44a6124)
- Interval for giveaway checks should be 15 seconds by default (19c2aa9)
- 2022.408.0 (e82202f)