### PR TITLE
Support Interaction reply for `GiveawaysManager#reroll`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ This framework includes amazing features such as:
     - RichEmbed Constructor
     - and more...
 
-This framework also supports both **JavaScript** and **TypeScript** languages.
-
 ## Developing a Discord bot using Givies-Framework
 
 - **Requirement:** You will need **[NodeJS v16.6.0+](https://nodejs.org)** installed.

--- a/lib/giveaways/Constants.ts
+++ b/lib/giveaways/Constants.ts
@@ -6,6 +6,12 @@ export interface BonusEntry {
     bonus(member?: Member): number | Promise<number>;
     cumulative?: boolean;
 }
+
+export interface InteractionOptions {
+    enabled?: boolean;
+    ephemeral?: boolean
+}
+
 export interface LastChanceOptions {
     enabled?: boolean;
     embedColor?: number;
@@ -87,6 +93,7 @@ export interface GiveawayRerollOptions {
         congrat?: string | AdvancedMessageContent;
         error?: string | AdvancedMessageContent;
     };
+    interactionOptions?: InteractionOptions;
 }
 
 export interface GiveawayData {
@@ -134,6 +141,11 @@ export const GiveawayMessages: GiveawaysMessages = {
     hostedBy: "Hosted by: {this.hostedBy}",
 };
 
+export const InteractionOptions: InteractionOptions = {
+    enabled: false,
+    ephemeral: false
+};
+
 export const LastChanceOptions: LastChanceOptions = {
     enabled: true,
     content: "⚠️ **LAST CHANCE TO ENTER** ⚠️",
@@ -173,10 +185,13 @@ export const GiveawayManagerOptions: GiveawaysManagerOptions = {
 export const GiveawayRerollOptions: GiveawayRerollOptions = {
     winnerCount: 1,
     messages: {
-        congrat:
-      "🎉 **New winner(s):** {winners}! Congratulations you won **{this.prize}**! \n {this.messageURL}",
+        congrat: "🎉 **New winner(s):** {winners}! Congratulations you won **{this.prize}**! \n {this.messageURL}",
         error: "No valid participations, no winners can be rerolled!",
     },
+    interactionOptions: {
+        enabled: false,
+        ephemeral: false
+    }
 };
 
 export const GiveawayData: GiveawayData = {

--- a/lib/giveaways/Giveaway.ts
+++ b/lib/giveaways/Giveaway.ts
@@ -1,6 +1,7 @@
 import {
     AdvancedMessageContent,
     Client,
+    CommandInteraction,
     Constants,
     Member,
     Message,
@@ -800,9 +801,10 @@ export class Giveaway extends EventEmitter {
     /**
      * Rerolls a giveaway
      * @param options The reroll options
+     * @param interaction Optional Eris' command interaction
      * @returns {Promise<Array<Member>>}
      */
-    reroll(options: GiveawayRerollOptions = {}): Promise<Member[]> {
+    reroll(options: GiveawayRerollOptions = {}, interaction?: CommandInteraction): Promise<Member[]> {
         return new Promise(async (resolve, reject) => {
             if (!this.ended) return reject(`Giveaway with Message ID ${this.messageID} hasn't ended`);
 
@@ -925,10 +927,18 @@ export class Giveaway extends EventEmitter {
             } else {
                 const embed = this.fillInEmbed((options.messages.error as AdvancedMessageContent).embed as RichEmbed);
 
-                this.channel.createMessage({
-                    content: this.fillInString((options.messages.error as AdvancedMessageContent).content || options.messages.error as string),
-                    embed: embed ?? null
-                });
+                if (options.interactionOptions.enabled) {
+                    interaction.createMessage({
+                        content: this.fillInString((options.messages.error as AdvancedMessageContent).content || options.messages.error as string),
+                        embeds: (options.messages.error as AdvancedMessageContent).embed ? [(options.messages.error as AdvancedMessageContent).embed] : [],
+                        flags: options.interactionOptions.ephemeral ? 64 : null
+                    });
+                } else {
+                    this.channel.createMessage({
+                        content: this.fillInString((options.messages.error as AdvancedMessageContent).content || options.messages.error as string),
+                        embed: embed ?? null
+                    });
+                }
 
                 resolve([]);
             }

--- a/lib/giveaways/GiveawaysManager.ts
+++ b/lib/giveaways/GiveawaysManager.ts
@@ -3,6 +3,7 @@
 import {
     AdvancedMessageContent,
     Client,
+    CommandInteraction,
     GuildTextableChannel,
     Member,
     Message,
@@ -490,19 +491,28 @@ export class GiveawaysManager extends EventEmitter {
      * Rerolls a giveaway
      * @param messageID The ID of the giveawya message
      * @param options Optional reroll options
+     * @param interaction Optional Eris' command interaction
      * @returns {Promise<Array<Member>>}
      */
-    reroll(messageID: string, options: GiveawayRerollOptions = {}): Promise<Member[]> {
+    reroll(messageID: string, options: GiveawayRerollOptions = {}, interaction?: CommandInteraction): Promise<Member[]> {
         return new Promise(async (resolve, reject) => {
             const giveaway = this.giveaways.find((g) => g.messageID === messageID);
 
             if (!giveaway) return reject(`No Giveaway found with message ID ${messageID}`);
 
-            giveaway.reroll(options).then((winners) => {
-                this.emit("giveawayRerolled", giveaway, winners);
-                resolve(winners);
-            }).catch(reject);
+            if (options.interactionOptions.enabled) {
+                giveaway.reroll(options, interaction).then((winners) => {
+                    this.emit("giveawayRerolled", giveaway, winners);
+                    resolve(winners);
+                });
+            } else {
+                giveaway.reroll(options).then((winners) => {
+                    this.emit("giveawayRerolled", giveaway, winners);
+                    resolve(winners);
+                }).catch(reject);
+            }
         });
+
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givies-framework",
-  "version": "2022.411.0",
+  "version": "2022.414.0",
   "description": "A framework to facilitate the development of Discord bots using Eris",
   "main": "src/index.js",
   "engines": {


### PR DESCRIPTION
This will allows an interaction reply on `GiveawaysManager#reroll` if participants are invalid instead of regular channel send. `GiveawaysManager#reroll` now supports 2 arguments. The first one is for reroll options and the second for Eris' `CommandInteraction`.

# Change Logs

- Add `InteractionOptions` interface (7f0224d)
- Support interaction (a511fc2, 5b2b37b)
- Version `2022.414.0` (5792edb)