### PR TITLE
Fix giveaway embed doesn't get updated after edit

### DIFF
--- a/lib/giveaways/Giveaway.ts
+++ b/lib/giveaways/Giveaway.ts
@@ -490,6 +490,19 @@ export class Giveaway extends EventEmitter {
                 );
             }
 
+            await this.manager.editGiveaway(this.messageID, this.data);
+
+            if (this.remainingTime <= 0) {
+                this.manager.end(this.messageID).catch(() => { });
+            } else {
+                const embed = this.manager.generateMainEmbed(this);
+
+                await this.message.edit({
+                    content: this.fillInString(this.messages.giveaway),
+                    embed: embed
+                }).catch(() => { });
+            }
+
             resolve(this);
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "givies-framework",
-  "version": "2022.417.0",
+  "version": "2022.418.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "givies-framework",
-      "version": "2022.417.0",
+      "version": "2022.418.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "givies-framework",
-  "version": "2022.417.0",
+  "version": "2022.418.0",
   "description": "A framework to facilitate the development of Discord bots using Eris",
   "main": "src/index.js",
   "engines": {


### PR DESCRIPTION
Fix an issue where the giveaway embed doesn't get edited after calling `GiveawaysManager#edit`.

## Change Logs

- Fix `Giveaway#edit` (f400ab3)
- Version `2022.418.0` (ceb0c89)